### PR TITLE
Use an empty string if process.env.TERM is missing

### DIFF
--- a/lib/detectTerminal.js
+++ b/lib/detectTerminal.js
@@ -42,7 +42,7 @@ exports.guessTerminal = function guessTerminal()
 	
 	var tTrueColor = process.env.COLORTERM && process.env.COLORTERM.match( /^(truecolor|24bits?)$/ ) ;
 	
-	var appId = process.env.COLORTERM && ! tTrueColor ? process.env.COLORTERM : process.env.TERM ;
+	var appId = process.env.COLORTERM && ! tTrueColor ? process.env.COLORTERM : ( process.env.TERM || '' );
 	
 	var ssh = process.env.SSH_CONNECTION ? true : false ;
 	


### PR DESCRIPTION
Should fix #26